### PR TITLE
removed .range(), added Integer .variance() .standardDeviation()

### DIFF
--- a/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
@@ -3,13 +3,25 @@ package org.nield.kotlinstatistics
 
 /**
  * Median
+ * The middle value in the list of numbers
  */
 fun Iterable<Int>.median(): Double = map(Int::toDouble).median()
-
 fun Sequence<Int>.median(): Double = asIterable().median()
+fun Array<Int>.median(): Double = asIterable().median()
 
 
 /**
- * Returns the difference between the highest and lowest values in the set.
+ * Variance
+ * The average of the squared differences from the Mean
  */
-fun Iterable<Int>.range(): Int = sorted().let { it.last() - it.first() }
+fun Iterable<Int>.variance(): Double = map(Int::toDouble).variance()
+fun Sequence<Int>.variance() = asIterable().variance()
+fun Array<Int>.variance() = asIterable().variance()
+
+/**
+ * Standard Deviation
+ * The square root of the variance
+ */
+fun Iterable<Int>.standardDeviation(): Double = map(Int::toDouble).standardDeviation()
+fun Sequence<Int>.standardDeviation() = asIterable().standardDeviation()
+fun Array<Int>.standardDeviation() = asIterable().standardDeviation()

--- a/src/test/kotlin/org/nield/kotlinstatistics/IntegerStatisticsTest.kt
+++ b/src/test/kotlin/org/nield/kotlinstatistics/IntegerStatisticsTest.kt
@@ -9,16 +9,33 @@ import org.junit.Test
 class IntegerStatisticsTest {
 
     @Test
-    fun testMedian1() = listOf(1, 9, 10).median() shouldEqualTo 9.0
+    fun testMedianList() = listOf(1, 9, 10).median() shouldEqualTo 9.0
 
     @Test
-    fun testMedian2() = sequenceOf(1, 4, 5, 90).median() shouldEqualTo 4.5
+    fun testMedianSequence() = sequenceOf(1, 4, 5, 90).median() shouldEqualTo 4.5
 
     @Test
-    fun testRange1() = listOf(2, 1, 10).range() shouldEqualTo 9
+    fun testMedianArray() = arrayOf(1, 11, 19).median() shouldEqualTo 11.0
+
 
     @Test
-    fun testRange2() = (1..30).range() shouldEqualTo 29
+    fun testVarianceList() = listOf(2, 3, 4).variance() shouldEqualTo 0.66666666666666666666666666666667
+
+    @Test
+    fun testVarianceSequence() = sequenceOf(1, 4, 6, 10).variance() shouldEqualTo 10.6875
+
+    @Test
+    fun testVarianceArray() = arrayOf(0, 5, 7).variance() shouldEqualTo 8.6666666666666666666666666666667
+
+
+    @Test
+    fun testStdDeviationList() = listOf(2, 3, 4).standardDeviation() shouldEqualTo 0.81649658092772603273242802490197
+
+    @Test
+    fun testStdDeviationSequence() = sequenceOf(0, 5, 7).standardDeviation() shouldEqualTo 2.9439202887759489515880142423198
+
+    @Test
+    fun testStdDeviationArray() = arrayOf(1, 4, 6, 10).standardDeviation() shouldEqualTo 3.2691742076555051641777364878947
 
 }
 


### PR DESCRIPTION
I removed the .range() and added .variance() and .standardDeviation() for Integer.

I am thinking we could keep the style of implementing the actual logic in the Double file and then for the Integer operations we just map to Double and use the Double functions. 

I also think it might be a good idea to keep the iterable version refer to the logic and then the other versions (Sequence, Array) can use .asIterable() and access the functionality there.

Any thoughts on this are welcome of course!