### PR TITLE
Add extension functions supporting groupBy results

### DIFF
--- a/src/main/kotlin/org/nield/kotlinstatistics/BigDecimalStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/BigDecimalStatistics.kt
@@ -1,10 +1,8 @@
 package org.nield.kotlinstatistics
 
 import org.nield.kotlinstatistics.range.ClosedOpenRange
-import org.nield.kotlinstatistics.range.Range
 import org.nield.kotlinstatistics.range.until
 import java.math.BigDecimal
-import java.util.concurrent.atomic.AtomicBoolean
 
 fun Sequence<BigDecimal>.sum() = fold(BigDecimal.ZERO) { x,y -> x + y }!!
 fun Iterable<BigDecimal>.sum() = fold(BigDecimal.ZERO) { x,y -> x + y }!!
@@ -113,5 +111,11 @@ inline fun <T, G> List<T>.binByBigDecimal(binSize: BigDecimal,
 }
 
 
+fun <K> Map<K, List<BigDecimal>>.sum(): Map<K, BigDecimal> = entries.map { it.key to it.value.sum() }.toMap()
+fun <K> Map<K, List<BigDecimal>>.average(): Map<K, BigDecimal> = entries.map { it.key to it.value.average() }.toMap()
 
+fun <K, V> Map<K, List<V>>.sumByBigDecimal(selector: (V) -> BigDecimal): Map<K, BigDecimal> =
+        entries.map { it.key to it.value.map(selector).sum() }.toMap()
 
+fun <K, V> Map<K, List<V>>.averageByBigDecimal(selector: (V) -> BigDecimal): Map<K, BigDecimal> =
+        entries.map { it.key to it.value.map(selector).average() }.toMap()

--- a/src/main/kotlin/org/nield/kotlinstatistics/DoubleStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/DoubleStatistics.kt
@@ -5,7 +5,6 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
 import org.nield.kotlinstatistics.range.Range
 import org.nield.kotlinstatistics.range.until
 import java.math.BigDecimal
-import java.util.concurrent.atomic.AtomicBoolean
 
 val DoubleArray.descriptiveStatistics: Descriptives get() = DescriptiveStatistics().apply { forEach { addValue(it) } }.let(::ApacheDescriptives)
 
@@ -128,3 +127,45 @@ inline fun <T, G> List<T>.binByDouble(binSize: Double,
             .toList()
             .let(::BinModel)
 }
+
+
+fun <K> Map<K, List<Double>>.sum(): Map<K, Double> = entries.map { it.key to it.value.sum() }.toMap()
+fun <K> Map<K, List<Double>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
+fun <K> Map<K, List<Double>>.intRange(): Map<K, ClosedFloatingPointRange<Double>> = entries.map { it.key to it.value.doubleRange() }.toMap()
+fun <K> Map<K, List<Double>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
+fun <K> Map<K, List<Double>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
+fun <K> Map<K, List<Double>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
+fun <K> Map<K, List<Double>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
+fun <K> Map<K, List<Double>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
+fun <K> Map<K, List<Double>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
+fun <K> Map<K, List<Double>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+
+fun <K, V> Map<K, List<V>>.averageByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).average() }.toMap()
+
+fun <K, V> Map<K, List<V>>.doubleRangeBy(selector: (V) -> Double): Map<K, ClosedFloatingPointRange<Double>> =
+        entries.map { it.key to it.value.map(selector).doubleRange() }.toMap()
+
+fun <K, V> Map<K, List<V>>.geometricMeanByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+
+fun <K, V> Map<K, List<V>>.medianByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).median() }.toMap()
+
+fun <K, V> Map<K, List<V>>.percentileByDouble(selector: (V) -> Double, percentile: Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+
+fun <K, V> Map<K, List<V>>.varianceByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumOfSquaresByDouble(selector: (V) -> Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+
+fun <K, V> Map<K, List<V>>.normalizeByDouble(selector: (V) -> Double): Map<K, DoubleArray> =
+        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+
+fun <K, V> Map<K, List<V>>.descriptiveStatisticsByDouble(selector: (V) -> Double): Map<K, Descriptives> =
+        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()

--- a/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
@@ -130,3 +130,45 @@ inline fun <T, G> List<T>.binByFloat(binSize: Float,
             .toList()
             .let(::BinModel)
 }
+
+
+fun <K> Map<K, List<Float>>.sum(): Map<K, Float> = entries.map { it.key to it.value.sum() }.toMap()
+fun <K> Map<K, List<Float>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
+fun <K> Map<K, List<Float>>.floatRange(): Map<K, ClosedFloatingPointRange<Float>> = entries.map { it.key to it.value.floatRange() }.toMap()
+fun <K> Map<K, List<Float>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
+fun <K> Map<K, List<Float>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
+fun <K> Map<K, List<Float>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
+fun <K> Map<K, List<Float>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
+fun <K> Map<K, List<Float>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
+fun <K> Map<K, List<Float>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
+fun <K> Map<K, List<Float>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumByFloat(selector: (V) -> Float): Map<K, Float> =
+        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+
+fun <K, V> Map<K, List<V>>.averageByFloat(selector: (V) -> Float): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).average() }.toMap()
+
+fun <K, V> Map<K, List<V>>.floatRangeBy(selector: (V) -> Float): Map<K, ClosedFloatingPointRange<Float>> =
+        entries.map { it.key to it.value.map(selector).floatRange() }.toMap()
+
+fun <K, V> Map<K, List<V>>.geometricMeanByFloat(selector: (V) -> Float): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+
+fun <K, V> Map<K, List<V>>.medianByFloat(selector: (V) -> Float): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).median() }.toMap()
+
+fun <K, V> Map<K, List<V>>.percentileByFloat(selector: (V) -> Float, percentile: Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+
+fun <K, V> Map<K, List<V>>.varianceByFloat(selector: (V) -> Float): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumOfSquaresByFloat(selector: (V) -> Float): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+
+fun <K, V> Map<K, List<V>>.normalizeByFloat(selector: (V) -> Float): Map<K, DoubleArray> =
+        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+
+fun <K, V> Map<K, List<V>>.descriptiveStatisticsByFloat(selector: (V) -> Float): Map<K, Descriptives> =
+        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()

--- a/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
@@ -122,3 +122,45 @@ inline fun <T, G> List<T>.binByInt(binSize: Int,
             .toList()
             .let(::BinModel)
 }
+
+
+fun <K> Map<K, List<Int>>.sum(): Map<K, Int> = entries.map { it.key to it.value.sum() }.toMap()
+fun <K> Map<K, List<Int>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
+fun <K> Map<K, List<Int>>.intRange(): Map<K, IntRange> = entries.map { it.key to it.value.intRange() }.toMap()
+fun <K> Map<K, List<Int>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
+fun <K> Map<K, List<Int>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
+fun <K> Map<K, List<Int>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
+fun <K> Map<K, List<Int>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
+fun <K> Map<K, List<Int>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
+fun <K> Map<K, List<Int>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
+fun <K> Map<K, List<Int>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumByInt(selector: (V) -> Int): Map<K, Int> =
+        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+
+fun <K, V> Map<K, List<V>>.averageByInt(selector: (V) -> Int): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).average() }.toMap()
+
+fun <K, V> Map<K, List<V>>.intRangeBy(selector: (V) -> Int): Map<K, IntRange> =
+        entries.map { it.key to it.value.map(selector).intRange() }.toMap()
+
+fun <K, V> Map<K, List<V>>.geometricMeanByInt(selector: (V) -> Int): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+
+fun <K, V> Map<K, List<V>>.medianByInt(selector: (V) -> Int): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).median() }.toMap()
+
+fun <K, V> Map<K, List<V>>.percentileByInt(selector: (V) -> Int, percentile: Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+
+fun <K, V> Map<K, List<V>>.varianceByInt(selector: (V) -> Int): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumOfSquaresByInt(selector: (V) -> Int): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+
+fun <K, V> Map<K, List<V>>.normalizeByInt(selector: (V) -> Int): Map<K, DoubleArray> =
+        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+
+fun <K, V> Map<K, List<V>>.descriptiveStatisticsByInt(selector: (V) -> Int): Map<K, Descriptives> =
+        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()

--- a/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
@@ -128,3 +128,45 @@ inline fun <T, G> List<T>.binByLong(binSize: Long,
             .toList()
             .let(::BinModel)
 }
+
+
+fun <K> Map<K, List<Long>>.sum(): Map<K, Long> = entries.map { it.key to it.value.sum() }.toMap()
+fun <K> Map<K, List<Long>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
+fun <K> Map<K, List<Long>>.longRange(): Map<K, Iterable<Long>> = entries.map { it.key to it.value.longRange() }.toMap()
+fun <K> Map<K, List<Long>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
+fun <K> Map<K, List<Long>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
+fun <K> Map<K, List<Long>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
+fun <K> Map<K, List<Long>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
+fun <K> Map<K, List<Long>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
+fun <K> Map<K, List<Long>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
+fun <K> Map<K, List<Long>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumByLong(selector: (V) -> Long): Map<K, Long> =
+        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+
+fun <K, V> Map<K, List<V>>.averageByLong(selector: (V) -> Long): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).average() }.toMap()
+
+fun <K, V> Map<K, List<V>>.LongRangeBy(selector: (V) -> Long): Map<K, Iterable<Long>> =
+        entries.map { it.key to it.value.map(selector).longRange() }.toMap()
+
+fun <K, V> Map<K, List<V>>.geometricMeanByLong(selector: (V) -> Long): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+
+fun <K, V> Map<K, List<V>>.medianByLong(selector: (V) -> Long): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).median() }.toMap()
+
+fun <K, V> Map<K, List<V>>.percentileByLong(selector: (V) -> Long, percentile: Double): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+
+fun <K, V> Map<K, List<V>>.varianceByLong(selector: (V) -> Long): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+
+fun <K, V> Map<K, List<V>>.sumOfSquaresByLong(selector: (V) -> Long): Map<K, Double> =
+        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+
+fun <K, V> Map<K, List<V>>.normalizeByLong(selector: (V) -> Long): Map<K, DoubleArray> =
+        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+
+fun <K, V> Map<K, List<V>>.descriptiveStatisticsByLong(selector: (V) -> Long): Map<K, Descriptives> =
+        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()


### PR DESCRIPTION
Adds extension functions supporting the calculation of statistics on the results of the `groupBy` method provided by the Kotlin standard library.

Two styles of extensions were added. 

First, if the `groupBy` is performed on an array or collection of `Double`, `Float`, `Int` or `Long`, the following extensions are provided:
* `sum`
* `average`
* `xxxRange` (where xxx is one of double, float, int or long)
* `geometricMean`
* `median`
* `percentile`
* `variance`
* `sumOfSquares`
* `normalize`
* `descriptiveStatistics`

Here is a simple example of what these extensions enable:
```
val list = arrayOf(1, 2, 3, 4, 5, 6)
val sums = list.groupBy { it % 2 }
               .sum()
println(sums) 
``` 
Output:  `{1=9, 0 = 12}`

Secondly, a set of "By" methods were added. Using `Double` as an example:
* `sumByDouble`
* `averageByDouble`
* `doubleRangeBy`
* `geometricMeanByDouble`
* `medianByDouble`
* `percentileByDouble`
* `varianceByDouble`
* `sumOfSquaresByDouble`
* `normalizeByDouble`
* `descriptiveStatisticsByDouble`

Unfortunately, the type suffix is needed here to resolve ambiguity (`(V) -> Double` and `(V) -> Int` boil down to the same thing). Note that "range" was already prefixed by the type so I left that as is.

Here is an example of what these extensions enable: (see README.md for a comparison)

```
class Item(val name: String, val value: Double)

val sequence = sequenceOf(
        Item("Alpha", 4.0),
        Item("Beta", 6.0),
        Item("Gamma", 7.2),
        Item("Delta", 9.2),
        Item("Epsilon", 6.8),
        Item("Zeta", 2.4),
        Item("Iota", 8.8)
)

// find sums by name length
val sumsByLengths = sequence.groupBy { it.name.length }
                            .sumByDouble { it.value }

println("Sums by lengths: $sumsByLengths")
```
Output: `Sums by lengths: {5=20.4, 4=17.200000000000003, 7=6.8}`