### PR TITLE
Migration to Kotlin 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 
-  ext.kotlin_version = '1.3.50'
+  ext.kotlin_version = '1.4.32'
 
 
   repositories {

--- a/src/main/kotlin/org/nield/kotlinstatistics/Aggregation.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/Aggregation.kt
@@ -12,7 +12,7 @@ inline fun <T,K,R> Sequence<T>.groupApply(crossinline keySelector: (T) -> K, cro
     val aggregatedMap = mutableMapOf<K,R>()
 
     for ((key, value) in map) {
-        aggregatedMap.put(key, aggregation(value))
+        aggregatedMap[key] = aggregation(value)
     }
     return aggregatedMap
 }
@@ -28,7 +28,7 @@ inline fun <T,V,K,R> Sequence<T>.groupApply(crossinline keySelector: (T) -> K, c
     val aggregatedMap = mutableMapOf<K, R>()
 
     for (entry in map.entries) {
-        aggregatedMap.put(entry.key, aggregation(entry.value))
+        aggregatedMap[entry.key] = aggregation(entry.value)
     }
     return aggregatedMap
 }

--- a/src/main/kotlin/org/nield/kotlinstatistics/BigDecimalStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/BigDecimalStatistics.kt
@@ -4,8 +4,8 @@ import org.nield.kotlinstatistics.range.ClosedOpenRange
 import org.nield.kotlinstatistics.range.until
 import java.math.BigDecimal
 
-fun Sequence<BigDecimal>.sum() = fold(BigDecimal.ZERO) { x,y -> x + y }!!
-fun Iterable<BigDecimal>.sum() = fold(BigDecimal.ZERO) { x,y -> x + y }!!
+fun Sequence<BigDecimal>.sum(): BigDecimal = fold(BigDecimal.ZERO) { x, y -> x + y }
+fun Iterable<BigDecimal>.sum(): BigDecimal = fold(BigDecimal.ZERO) { x, y -> x + y }
 
 fun Sequence<BigDecimal>.average() = toList().let { list ->
     list.sum() / BigDecimal.valueOf(list.count().toDouble())
@@ -84,8 +84,8 @@ inline fun <T, G> List<T>.binByBigDecimal(binSize: BigDecimal,
 ): BinModel<G, BigDecimal> {
 
     val groupedByC = asSequence().groupBy(valueSelector)
-    val minC = rangeStart?:groupedByC.keys.min()!!
-    val maxC = groupedByC.keys.max()!!
+    val minC = rangeStart?:groupedByC.keys.minOrNull()!!
+    val maxC = groupedByC.keys.maxOrNull()!!
 
     val bins = mutableListOf<ClosedOpenRange<BigDecimal>>().apply {
         var currentRangeStart = minC
@@ -114,13 +114,13 @@ fun <T, C : Comparable<C>> BinModel<List<T>, C>.averageByBigDecimal(selector: (T
         bins.map { Bin(it.range, it.value.map(selector).average()) }
 
 fun <T, C : Comparable<C>> BinModel<List<T>, C>.sumByBigDecimal(selector: (T) -> Double) =
-        bins.map { Bin(it.range, it.value.map(selector).sum()) }
+        bins.map { Bin(it.range, it.value.sumOf(selector)) }
 
-fun <K> Map<K, List<BigDecimal>>.sum(): Map<K, BigDecimal> = entries.map { it.key to it.value.sum() }.toMap()
-fun <K> Map<K, List<BigDecimal>>.average(): Map<K, BigDecimal> = entries.map { it.key to it.value.average() }.toMap()
+fun <K> Map<K, List<BigDecimal>>.sum(): Map<K, BigDecimal> = mapValues { it.value.sum() }
+fun <K> Map<K, List<BigDecimal>>.average(): Map<K, BigDecimal> = mapValues { it.value.average() }
 
 fun <K, V> Map<K, List<V>>.sumByBigDecimal(selector: (V) -> BigDecimal): Map<K, BigDecimal> =
-        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+        mapValues { it.value.map(selector).sum() }
 
 fun <K, V> Map<K, List<V>>.averageByBigDecimal(selector: (V) -> BigDecimal): Map<K, BigDecimal> =
-        entries.map { it.key to it.value.map(selector).average() }.toMap()
+        mapValues { it.value.map(selector).average() }

--- a/src/main/kotlin/org/nield/kotlinstatistics/Bin.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/Bin.kt
@@ -3,7 +3,6 @@ package org.nield.kotlinstatistics
 import org.nield.kotlinstatistics.range.ClosedOpenRange
 import org.nield.kotlinstatistics.range.Range
 import org.nield.kotlinstatistics.range.XClosedRange
-import org.nield.kotlinstatistics.range.until
 import java.util.concurrent.atomic.AtomicBoolean
 
 class Bin<T,C: Comparable<C>>(val range: Range<C>, val value: T) {
@@ -36,8 +35,8 @@ inline fun <T, C: Comparable<C>, G> List<T>.binByComparable(binIncrements: Int,
                                                             ): BinModel<G, C> {
 
     val groupedByC = asSequence().groupBy(valueSelector)
-    val minC = rangeStart?:groupedByC.keys.min()!!
-    val maxC = groupedByC.keys.max()!!
+    val minC = rangeStart?:groupedByC.keys.minOrNull()!!
+    val maxC = groupedByC.keys.maxOrNull()!!
 
     val bins = mutableListOf<Range<C>>().apply {
         var currentRangeStart = minC

--- a/src/main/kotlin/org/nield/kotlinstatistics/Clustering.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/Clustering.kt
@@ -49,7 +49,7 @@ inline fun <T> Collection<T>.multiKMeansCluster(k: Int, maxIterations: Int, tria
                 .let { list ->
                     KMeansPlusPlusClusterer<ClusterInput<T>>(k, maxIterations)
                             .let {
-                                MultiKMeansPlusPlusClusterer<ClusterInput<T>>(it, trialCount)
+                                MultiKMeansPlusPlusClusterer(it, trialCount)
                                         .cluster(list)
                                         .map {
                                             Centroid(DoublePoint(-1.0,-1.0), it.points.map { it.item })

--- a/src/main/kotlin/org/nield/kotlinstatistics/ComparableStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/ComparableStatistics.kt
@@ -2,13 +2,13 @@ package org.nield.kotlinstatistics
 
 
 inline fun <T, R : Comparable<R>,K> Sequence<T>.minBy(crossinline keySelector: (T) -> K, crossinline valueSelector: (T) -> R) =
-        groupApply(keySelector, valueSelector) { it.min() }
+        groupApply(keySelector, valueSelector) { it.minOrNull() }
 
 inline fun <T, R : Comparable<R>,K>  Iterable<T>.minBy(crossinline keySelector: (T) -> K, crossinline valueSelector: (T) -> R) =
         asSequence().minBy(keySelector, valueSelector)
 
 fun <K,R: Comparable<R>> Sequence<Pair<K, R>>.minBy() =
-        groupApply({it.first}, {it.second}) { it.min() }
+        groupApply({it.first}, {it.second}) { it.minOrNull() }
 
 fun <K, R: Comparable<R>> Iterable<Pair<K, R>>.minBy() = asSequence().minBy()
 
@@ -18,20 +18,20 @@ fun <K, R: Comparable<R>> Iterable<Pair<K, R>>.minBy() = asSequence().minBy()
 
 
 inline fun <T, R : Comparable<R>,K> Sequence<T>.maxBy(crossinline keySelector: (T) -> K, crossinline valueSelector: (T) -> R) =
-        groupApply(keySelector, valueSelector) { it.max() }
+        groupApply(keySelector, valueSelector) { it.maxOrNull() }
 
 inline fun <T, R : Comparable<R>,K>  Iterable<T>.maxBy(crossinline keySelector: (T) -> K, crossinline valueSelector: (T) -> R) =
         asSequence().maxBy(keySelector, valueSelector)
 
 
 fun <T : Comparable<T>,K> Sequence<Pair<K, T>>.maxBy() =
-        groupApply({it.first}, {it.second}) { it.max() }
+        groupApply({it.first}, {it.second}) { it.maxOrNull() }
 
 fun <T : Comparable<T>,K> Iterable<Pair<K, T>>.maxBy() = asSequence().maxBy()
 
 
 fun <T: Comparable<T>> Sequence<T>.range() = toList().range()
-fun <T: Comparable<T>> Iterable<T>.range() = toList().let { (it.min()?:throw Exception("At least one element must be present"))..(it.max()?:throw Exception("At least one element must be present")) }
+fun <T: Comparable<T>> Iterable<T>.range() = toList().let { (it.minOrNull()?:throw Exception("At least one element must be present"))..(it.maxOrNull()?:throw Exception("At least one element must be present")) }
 
 inline fun <T, R : Comparable<R>,K> Sequence<T>.rangeBy(crossinline keySelector: (T) -> K, crossinline valueSelector: (T) -> R) =
         groupApply(keySelector, valueSelector) { it.range() }

--- a/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
@@ -1,6 +1,7 @@
+package org.nield.kotlinstatistics
+
 import org.apache.commons.math3.stat.StatUtils
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics
-import org.nield.kotlinstatistics.*
 import org.nield.kotlinstatistics.range.Range
 import org.nield.kotlinstatistics.range.until
 import java.math.BigDecimal

--- a/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/FloatStatistics.kt
@@ -10,7 +10,7 @@ val FloatArray.descriptiveStatistics get(): Descriptives = DescriptiveStatistics
 
 fun FloatArray.geometricMean() = asSequence().geometricMean()
 fun FloatArray.median() = percentile(50.0)
-fun FloatArray.percentile(percentile: Double) = asSequence().percentile(50.0)
+fun FloatArray.percentile(percentile: Double) = asSequence().percentile(percentile)
 fun FloatArray.variance() = asSequence().variance()
 fun FloatArray.sumOfSquares() = asSequence().sumOfSquares()
 fun FloatArray.standardDeviation() = asSequence().standardDeviation()

--- a/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/IntegerStatistics.kt
@@ -49,7 +49,7 @@ fun <K> Iterable<Pair<K,Int>>.averageBy() = asSequence().averageBy()
 
 
 fun Sequence<Int>.intRange() = toList().intRange()
-fun Iterable<Int>.intRange() = toList().let { (it.min()?:throw Exception("At least one element must be present"))..(it.max()?:throw Exception("At least one element must be present")) }
+fun Iterable<Int>.intRange() = toList().let { (it.minOrNull()?:throw Exception("At least one element must be present"))..(it.maxOrNull()?:throw Exception("At least one element must be present")) }
 
 inline fun <T,K> Sequence<T>.intRangeBy(crossinline keySelector: (T) -> K, crossinline intSelector: (T) -> Int) =
         groupApply(keySelector, intSelector) { it.range() }
@@ -98,8 +98,8 @@ inline fun <T, G> List<T>.binByInt(binSize: Int,
 ): BinModel<G, Int> {
 
     val groupedByC = asSequence().groupBy(valueSelector)
-    val minC = rangeStart?:groupedByC.keys.min()!!
-    val maxC = groupedByC.keys.max()!!
+    val minC = rangeStart?:groupedByC.keys.minOrNull()!!
+    val maxC = groupedByC.keys.maxOrNull()!!
 
     val bins = mutableListOf<Range<Int>>().apply {
         var currentRangeStart = minC
@@ -124,7 +124,7 @@ inline fun <T, G> List<T>.binByInt(binSize: Int,
 }
 
 fun <T, C : Comparable<C>> BinModel<List<T>, C>.sumByInt(selector: (T) -> Int): BinModel<Int, C> =
-        BinModel(bins.map { Bin(it.range, it.value.map(selector).sum()) })
+        BinModel(bins.map { Bin(it.range, it.value.sumOf(selector)) })
 
 fun <T, C : Comparable<C>> BinModel<List<T>, C>.averageByInt(selector: (T) -> Int): BinModel<Double, C> =
         BinModel(bins.map { Bin(it.range, it.value.map(selector).average()) })
@@ -154,43 +154,43 @@ fun <T, C : Comparable<C>> BinModel<List<T>, C>.descriptiveStatisticsByInt(selec
         BinModel(bins.map { Bin(it.range, it.value.map(selector).descriptiveStatistics) })
 
 
-fun <K> Map<K, List<Int>>.sum(): Map<K, Int> = entries.map { it.key to it.value.sum() }.toMap()
-fun <K> Map<K, List<Int>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
-fun <K> Map<K, List<Int>>.intRange(): Map<K, IntRange> = entries.map { it.key to it.value.intRange() }.toMap()
-fun <K> Map<K, List<Int>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
-fun <K> Map<K, List<Int>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
-fun <K> Map<K, List<Int>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
-fun <K> Map<K, List<Int>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
-fun <K> Map<K, List<Int>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
-fun <K> Map<K, List<Int>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
-fun <K> Map<K, List<Int>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+fun <K> Map<K, List<Int>>.sum(): Map<K, Int> = mapValues { it.value.sum() }
+fun <K> Map<K, List<Int>>.average(): Map<K, Double> = mapValues { it.value.average() }
+fun <K> Map<K, List<Int>>.intRange(): Map<K, IntRange> = mapValues { it.value.intRange() }
+fun <K> Map<K, List<Int>>.geometricMean(): Map<K, Double> = mapValues { it.value.geometricMean() }
+fun <K> Map<K, List<Int>>.median(): Map<K, Double> = mapValues { it.value.median() }
+fun <K> Map<K, List<Int>>.percentile(percentile: Double): Map<K, Double> = mapValues { it.value.percentile(percentile) }
+fun <K> Map<K, List<Int>>.variance(): Map<K, Double> = mapValues { it.value.variance() }
+fun <K> Map<K, List<Int>>.sumOfSquares(): Map<K, Double> = mapValues { it.value.sumOfSquares() }
+fun <K> Map<K, List<Int>>.normalize(): Map<K, DoubleArray> = mapValues { it.value.normalize() }
+fun <K> Map<K, List<Int>>.descriptiveStatistics(): Map<K, Descriptives> = mapValues { it.value.descriptiveStatistics }
 
 fun <K, V> Map<K, List<V>>.sumByInt(selector: (V) -> Int): Map<K, Int> =
-        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+        mapValues { it.value.sumOf(selector) }
 
 fun <K, V> Map<K, List<V>>.averageByInt(selector: (V) -> Int): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).average() }.toMap()
+        mapValues { it.value.map(selector).average() }
 
 fun <K, V> Map<K, List<V>>.intRangeBy(selector: (V) -> Int): Map<K, IntRange> =
-        entries.map { it.key to it.value.map(selector).intRange() }.toMap()
+        mapValues { it.value.map(selector).intRange() }
 
 fun <K, V> Map<K, List<V>>.geometricMeanByInt(selector: (V) -> Int): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+        mapValues { it.value.map(selector).geometricMean() }
 
 fun <K, V> Map<K, List<V>>.medianByInt(selector: (V) -> Int): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).median() }.toMap()
+        mapValues { it.value.map(selector).median() }
 
 fun <K, V> Map<K, List<V>>.percentileByInt(selector: (V) -> Int, percentile: Double): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+        mapValues { it.value.map(selector).percentile(percentile) }
 
 fun <K, V> Map<K, List<V>>.varianceByInt(selector: (V) -> Int): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+        mapValues { it.value.map(selector).variance() }
 
 fun <K, V> Map<K, List<V>>.sumOfSquaresByInt(selector: (V) -> Int): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+        mapValues { it.value.map(selector).sumOfSquares() }
 
 fun <K, V> Map<K, List<V>>.normalizeByInt(selector: (V) -> Int): Map<K, DoubleArray> =
-        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+        mapValues { it.value.map(selector).normalize() }
 
 fun <K, V> Map<K, List<V>>.descriptiveStatisticsByInt(selector: (V) -> Int): Map<K, Descriptives> =
-        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()
+        mapValues { it.value.map(selector).descriptiveStatistics }

--- a/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
@@ -53,7 +53,7 @@ fun <K> Iterable<Pair<K,Long>>.averageBy() = asSequence().averageBy()
 
 
 fun Sequence<Long>.longRange() = toList().longRange()
-fun Iterable<Long>.longRange() = toList().let { (it.min()?:throw Exception("At least one element must be present"))..(it.max()?:throw Exception("At least one element must be present")) }
+fun Iterable<Long>.longRange() = toList().let { (it.minOrNull()?:throw Exception("At least one element must be present"))..(it.maxOrNull()?:throw Exception("At least one element must be present")) }
 
 inline fun <T,K> Sequence<T>.longRangeBy(crossinline keySelector: (T) -> K, crossinline longSelector: (T) -> Long) =
         groupApply(keySelector, longSelector) { it.range() }
@@ -103,8 +103,8 @@ inline fun <T, G> List<T>.binByLong(binSize: Long,
 ): BinModel<G, Long> {
 
     val groupedByC = asSequence().groupBy(valueSelector)
-    val minC = rangeStart?:groupedByC.keys.min()!!
-    val maxC = groupedByC.keys.max()!!
+    val minC = rangeStart?:groupedByC.keys.minOrNull()!!
+    val maxC = groupedByC.keys.maxOrNull()!!
 
     val bins = mutableListOf<XClosedRange<Long>>().apply {
         var currentRangeStart = minC
@@ -129,7 +129,7 @@ inline fun <T, G> List<T>.binByLong(binSize: Long,
 }
 
 fun <T, C : Comparable<C>> BinModel<List<T>, C>.sumByLong(selector: (T) -> Long): BinModel<Long, C> =
-        BinModel(bins.map { Bin(it.range, it.value.map(selector).sum()) })
+        BinModel(bins.map { Bin(it.range, it.value.sumOf(selector)) })
 
 fun <T, C : Comparable<C>> BinModel<List<T>, C>.averageByLong(selector: (T) -> Long): BinModel<Double, C> =
         BinModel(bins.map { Bin(it.range, it.value.map(selector).average()) })
@@ -159,43 +159,43 @@ fun <T, C : Comparable<C>> BinModel<List<T>, C>.descriptiveStatisticsByLong(sele
         BinModel(bins.map { Bin(it.range, it.value.map(selector).descriptiveStatistics) })
 
 
-fun <K> Map<K, List<Long>>.sum(): Map<K, Long> = entries.map { it.key to it.value.sum() }.toMap()
-fun <K> Map<K, List<Long>>.average(): Map<K, Double> = entries.map { it.key to it.value.average() }.toMap()
-fun <K> Map<K, List<Long>>.longRange(): Map<K, Iterable<Long>> = entries.map { it.key to it.value.longRange() }.toMap()
-fun <K> Map<K, List<Long>>.geometricMean(): Map<K, Double> = entries.map { it.key to it.value.geometricMean() }.toMap()
-fun <K> Map<K, List<Long>>.median(): Map<K, Double> = entries.map { it.key to it.value.median() }.toMap()
-fun <K> Map<K, List<Long>>.percentile(percentile: Double): Map<K, Double> = entries.map { it.key to it.value.percentile(percentile) }.toMap()
-fun <K> Map<K, List<Long>>.variance(): Map<K, Double> = entries.map { it.key to it.value.variance() }.toMap()
-fun <K> Map<K, List<Long>>.sumOfSquares(): Map<K, Double> = entries.map { it.key to it.value.sumOfSquares() }.toMap()
-fun <K> Map<K, List<Long>>.normalize(): Map<K, DoubleArray> = entries.map { it.key to it.value.normalize() }.toMap()
-fun <K> Map<K, List<Long>>.descriptiveStatistics(): Map<K, Descriptives> = entries.map { it.key to it.value.descriptiveStatistics }.toMap()
+fun <K> Map<K, List<Long>>.sum(): Map<K, Long> = mapValues { it.value.sum() }
+fun <K> Map<K, List<Long>>.average(): Map<K, Double> = mapValues { it.value.average() }
+fun <K> Map<K, List<Long>>.longRange(): Map<K, Iterable<Long>> = mapValues { it.value.longRange() }
+fun <K> Map<K, List<Long>>.geometricMean(): Map<K, Double> = mapValues { it.value.geometricMean() }
+fun <K> Map<K, List<Long>>.median(): Map<K, Double> = mapValues { it.value.median() }
+fun <K> Map<K, List<Long>>.percentile(percentile: Double): Map<K, Double> = mapValues { it.value.percentile(percentile) }
+fun <K> Map<K, List<Long>>.variance(): Map<K, Double> = mapValues { it.value.variance() }
+fun <K> Map<K, List<Long>>.sumOfSquares(): Map<K, Double> = mapValues { it.value.sumOfSquares() }
+fun <K> Map<K, List<Long>>.normalize(): Map<K, DoubleArray> = mapValues { it.value.normalize() }
+fun <K> Map<K, List<Long>>.descriptiveStatistics(): Map<K, Descriptives> = mapValues { it.value.descriptiveStatistics }
 
 fun <K, V> Map<K, List<V>>.sumByLong(selector: (V) -> Long): Map<K, Long> =
-        entries.map { it.key to it.value.map(selector).sum() }.toMap()
+        mapValues { it.value.sumOf(selector) }
 
 fun <K, V> Map<K, List<V>>.averageByLong(selector: (V) -> Long): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).average() }.toMap()
+        mapValues { it.value.map(selector).average() }
 
 fun <K, V> Map<K, List<V>>.longRangeBy(selector: (V) -> Long): Map<K, Iterable<Long>> =
-        entries.map { it.key to it.value.map(selector).longRange() }.toMap()
+        mapValues { it.value.map(selector).longRange() }
 
 fun <K, V> Map<K, List<V>>.geometricMeanByLong(selector: (V) -> Long): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).geometricMean() }.toMap()
+        mapValues { it.value.map(selector).geometricMean() }
 
 fun <K, V> Map<K, List<V>>.medianByLong(selector: (V) -> Long): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).median() }.toMap()
+        mapValues { it.value.map(selector).median() }
 
 fun <K, V> Map<K, List<V>>.percentileByLong(selector: (V) -> Long, percentile: Double): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).percentile(percentile) }.toMap()
+        mapValues { it.value.map(selector).percentile(percentile) }
 
 fun <K, V> Map<K, List<V>>.varianceByLong(selector: (V) -> Long): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).variance() }.toMap()
+        mapValues { it.value.map(selector).variance() }
 
 fun <K, V> Map<K, List<V>>.sumOfSquaresByLong(selector: (V) -> Long): Map<K, Double> =
-        entries.map { it.key to it.value.map(selector).sumOfSquares() }.toMap()
+        mapValues { it.value.map(selector).sumOfSquares() }
 
 fun <K, V> Map<K, List<V>>.normalizeByLong(selector: (V) -> Long): Map<K, DoubleArray> =
-        entries.map { it.key to it.value.map(selector).normalize() }.toMap()
+        mapValues { it.value.map(selector).normalize() }
 
 fun <K, V> Map<K, List<V>>.descriptiveStatisticsByLong(selector: (V) -> Long): Map<K, Descriptives> =
-        entries.map { it.key to it.value.map(selector).descriptiveStatistics }.toMap()
+        mapValues { it.value.map(selector).descriptiveStatistics }

--- a/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/LongStatistics.kt
@@ -176,7 +176,7 @@ fun <K, V> Map<K, List<V>>.sumByLong(selector: (V) -> Long): Map<K, Long> =
 fun <K, V> Map<K, List<V>>.averageByLong(selector: (V) -> Long): Map<K, Double> =
         entries.map { it.key to it.value.map(selector).average() }.toMap()
 
-fun <K, V> Map<K, List<V>>.LongRangeBy(selector: (V) -> Long): Map<K, Iterable<Long>> =
+fun <K, V> Map<K, List<V>>.longRangeBy(selector: (V) -> Long): Map<K, Iterable<Long>> =
         entries.map { it.key to it.value.map(selector).longRange() }.toMap()
 
 fun <K, V> Map<K, List<V>>.geometricMeanByLong(selector: (V) -> Long): Map<K, Double> =

--- a/src/main/kotlin/org/nield/kotlinstatistics/Ranges.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/Ranges.kt
@@ -12,7 +12,7 @@ class OpenDoubleRange(
     fun lessThanOrEquals(a: Double, b: Double): Boolean = a <= b
 
     operator fun contains(value: Double): Boolean = value >= _start && value < _endExclusive
-    fun isEmpty(): Boolean = !(_start <= _endExclusive)
+    fun isEmpty(): Boolean = _start > _endExclusive
 
     override fun equals(other: Any?): Boolean {
         return other is OpenDoubleRange && (isEmpty() && other.isEmpty() ||

--- a/src/main/kotlin/org/nield/kotlinstatistics/range/XClosedRange.kt
+++ b/src/main/kotlin/org/nield/kotlinstatistics/range/XClosedRange.kt
@@ -7,7 +7,7 @@ package org.nield.kotlinstatistics.range
  *
  * binning and histograms.
  */
-class XClosedRange<T: Comparable<T>>(val startInclusive: T, override val endInclusive: T): Range<T>, kotlin.ranges.ClosedRange<T> by startInclusive..endInclusive {
+class XClosedRange<T: Comparable<T>>(val startInclusive: T, override val endInclusive: T): Range<T>, ClosedRange<T> by startInclusive..endInclusive {
 
     init {
         if (startInclusive > endInclusive) throw InvalidRangeException("[$startInclusive..$endInclusive] is an invalid XClosedRange!")

--- a/src/test/kotlin/org/nield/kotlinstatistics/CategoricalStatisticsTest.kt
+++ b/src/test/kotlin/org/nield/kotlinstatistics/CategoricalStatisticsTest.kt
@@ -1,7 +1,7 @@
 package org.nield.kotlinstatistics
 
-import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlin.test.assertEquals
 
 class CategoricalStatisticsTest {
 
@@ -9,25 +9,28 @@ class CategoricalStatisticsTest {
 
     @Test
     fun testMode1() {
-        assertTrue(listOf(2,54,67,3,4,5,2,2).mode().toSet() == setOf(2))
+        assertEquals(setOf(2),
+            listOf(2,54,67,3,4,5,2,2).mode().toSet())
     }
     @Test
     fun testMode2() {
-        assertTrue(listOf(2,4,54,4,67,3,4,5,2,2).mode().toSet() == setOf(2,4))
+        assertEquals(setOf(2,4),
+            listOf(2,4,54,4,67,3,4,5,2,2).mode().toSet())
     }
     @Test
     fun testGroupApply() {
-        strings.groupApply( {it.length}, { it.asSequence().flatMap { it.split("").asSequence() }.filter { it.isNotEmpty() }.count() })
-                .let { assertTrue(it == mapOf(5 to 15, 4 to 4, 7 to 7)) }
+        assertEquals(mapOf(5 to 15, 4 to 4, 7 to 7),
+            strings.groupApply( {it.length}, { it.asSequence().flatMap { it.split("").asSequence() }.filter { it.isNotEmpty() }.count() })
+        )
     }
 
     @Test
     fun countBy() {
 
-        strings.map { it.length }.countBy()
-                .let { it == mapOf(5 to 3, 4 to 1, 7 to 1)}
+        assertEquals(mapOf(5 to 3, 4 to 1, 7 to 1),
+            strings.map { it.length }.countBy())
 
-        strings.countBy { it.length }
-                .let { it == mapOf(5 to 3, 4 to 1, 7 to 1)}
+        assertEquals(mapOf(5 to 3, 4 to 1, 7 to 1),
+            strings.countBy { it.length })
     }
 }


### PR DESCRIPTION
Because Kotlin 1.5 is already out, it might become dangerous for users to keep depending on a lib compiled with 1.3.

Notes
- mapValues will skip creating an intermediate collection and a `Pair` per entry
- sumOf also avoids an intermediate collection